### PR TITLE
Include Post ID in table after synchronisation

### DIFF
--- a/includes/RplusGoogleAnalytics.php
+++ b/includes/RplusGoogleAnalytics.php
@@ -230,7 +230,7 @@ class RplusGoogleAnalytics {
             /* debug */ if ( $debugoutput ) {
                 $wp_post = __( 'No related post/page found', 'rpluswptopcontent' );
                 if ( ! empty( $postid ) ) {
-                    $wp_post = '<a href="'.site_url( $url ).'" target="_blank">'.get_the_title( $postid ).'</a> | ID: <a href="'.get_edit_post_link( $postid ).' title="Beitrag bearbeiten"><code>'.esc_attr( $postid ).'</code></a>';
+                    $wp_post = '<a href="'.site_url( $url ).'" target="_blank">'.get_the_title( $postid ).'</a> | ID: <a href="'.get_edit_post_link( $postid ).'" title="Beitrag bearbeiten"><code>'.esc_attr( $postid ).'</code></a>';
                 }
                 echo  '<tr>'
                     .'<td valign="top" style="vertical-align: top;">'.$page[0].'</td>'

--- a/includes/RplusGoogleAnalytics.php
+++ b/includes/RplusGoogleAnalytics.php
@@ -230,7 +230,7 @@ class RplusGoogleAnalytics {
             /* debug */ if ( $debugoutput ) {
                 $wp_post = __( 'No related post/page found', 'rpluswptopcontent' );
                 if ( ! empty( $postid ) ) {
-                    $wp_post = '<a href="'.site_url( $url ).'" target="_blank">'.get_the_title( $postid ).'</a> | ID: <a href="'.get_edit_post_link( $postid ).'" title="Beitrag bearbeiten"><code>'.esc_attr( $postid ).'</code></a>';
+                    $wp_post = '<a href="'.site_url( $url ).'" target="_blank">'.get_the_title( $postid ).'</a> | ID: <a href="'.get_edit_post_link( $postid ).'" title="' . __( 'Edit post', 'rpluswptopcontent' ) . '"><code>'.esc_attr( $postid ).'</code></a>';
                 }
                 echo  '<tr>'
                     .'<td valign="top" style="vertical-align: top;">'.$page[0].'</td>'

--- a/includes/RplusGoogleAnalytics.php
+++ b/includes/RplusGoogleAnalytics.php
@@ -230,7 +230,7 @@ class RplusGoogleAnalytics {
             /* debug */ if ( $debugoutput ) {
                 $wp_post = __( 'No related post/page found', 'rpluswptopcontent' );
                 if ( ! empty( $postid ) ) {
-                    $wp_post = '<a href="'.site_url( $url ).'" target="_blank">'.get_the_title( $postid ).'</a>';
+                    $wp_post = '<a href="'.site_url( $url ).'" target="_blank">'.get_the_title( $postid ).'</a> | ID: <a href="'.get_edit_post_link( $postid ).' title="Beitrag bearbeiten"><code>'.esc_attr( $postid ).'</code></a>';
                 }
                 echo  '<tr>'
                     .'<td valign="top" style="vertical-align: top;">'.$page[0].'</td>'


### PR DESCRIPTION
On the settings screen for the plugin after the sync with GA is done, we show a table with the matched & unmatched URIs and their posts in WP. For convenience and as an additional help, after the Post permalink we now show the Post ID with edit link.